### PR TITLE
Add entrypoint to allow running as a command-line util

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,5 +13,10 @@ setuptools.setup(
     author_email = 'henryweickert@gmail.com',
     url = 'https://github.com/hweickert/where',
     keywords = ['where', 'which'],
-    install_requires=["itermate==1.0.1"]
+    install_requires=["itermate==1.0.1", "six>=1.3.0"],
+    entry_points={
+        'console_scripts': [
+            'where = where.__main__:main',
+        ]
+    },
 )

--- a/where/__main__.py
+++ b/where/__main__.py
@@ -1,0 +1,22 @@
+from __future__ import absolute_import
+
+import sys
+import argparse
+
+import where
+
+
+def main():
+    parser = argparse.ArgumentParser(description=
+        "Find the locations of a file in the environment's paths")
+
+    parser.add_argument('filename', type=str, help='The filename to be found')
+
+    args = parser.parse_args()
+
+    for result in where.iwhere(args.filename):
+        print(result)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Allows calling from the command-line like:

```
$ pip install where
$ where python
/usr/local/bin/python
/usr/bin/python
```
