### PR TITLE
Add Python 3 compatibility (drops 2.6)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,5 +13,4 @@ setuptools.setup(
     author_email = 'henryweickert@gmail.com',
     url = 'https://github.com/hweickert/where',
     keywords = ['where', 'which'],
-    install_requires=["itermate==1.0.1"]
 )

--- a/where/__init__.py
+++ b/where/__init__.py
@@ -1,8 +1,8 @@
+from __future__ import absolute_import
+
 import os
 import platform
 import itertools
-import itermate
-
 
 
 def where( filename ):
@@ -15,7 +15,7 @@ def first( filename ):
     """ Returns first matching file path. """
 
     try:
-        return iwhere(filename).next()
+        return next(iwhere(filename))
     except StopIteration:
         return None
 
@@ -24,20 +24,31 @@ def iwhere( filename ):
     """ Like where() but returns an iterator. """
 
     possible_paths =      _gen_possible_matches( filename )
-    existing_file_paths = itertools.ifilter( os.path.isfile, possible_paths )
+    existing_file_paths = ( p for p in possible_paths if os.path.isfile(p) )
     return existing_file_paths
+
+
+def _gen_windows_matches( paths ):
+    for path in paths:
+        yield path
+        yield path + ".bat"
+        yield path + ".com"
+        yield path + ".exe"
 
 
 def _gen_possible_matches( filename ):
     path_parts =     os.environ.get("PATH", "").split( os.pathsep )
     path_parts =     itertools.chain( (os.curdir,), path_parts )
-    possible_paths = itertools.imap( lambda path_part: os.path.join(path_part, filename), path_parts )
+    possible_paths = ( os.path.join(path_part, filename) for path_part in path_parts )
 
     if platform.system() == "Windows":
-        possible_paths = itermate.imapchain( lambda path: (path, path+".bat", path+".com", path+".exe"), possible_paths )
+        possible_paths = _gen_windows_matches(possible_paths)
 
-    possible_paths = itertools.imap( os.path.abspath, possible_paths )
+    possible_paths = ( os.path.abspath(p) for p in possible_paths )
 
-    result = itermate.unique( possible_paths )
-
-    return result
+    results = set()
+    for result in possible_paths:
+        if result in results:
+            continue
+        yield result
+        results.add(result)


### PR DESCRIPTION
Reword some `filter`, `map` stuff as generator comprehensions to avoid 2/3 incompatibilities. `iter.next()` &rarr; `next(iter)` (requires 2.7?). Dropped `itermate` to avoid its rename incompatibilities.

I could add 2.6 compatibility if desired, probably throw in the `six` compat library.
